### PR TITLE
HL API integration

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -245,6 +245,9 @@ function plugin_vip_executeActions($options) {
 }
 
 function plugin_vip_redefine_api_schemas(array $data): array {
+    if (!Session::haveRight('plugin_vip', READ)) {
+        return $data;
+    }
     foreach ($data['schemas'] as &$schema) {
         if (!isset($schema['x-itemtype'])) {
             continue;

--- a/hook.php
+++ b/hook.php
@@ -243,3 +243,54 @@ function plugin_vip_executeActions($options) {
    $vip = new PluginVipRuleVip();
    return $vip->executeActions($options['action'], $options['output'], $options['params']);
 }
+
+function plugin_vip_redefine_api_schemas(array $data): array {
+    foreach ($data['schemas'] as &$schema) {
+        if (!isset($schema['x-itemtype'])) {
+            continue;
+        }
+        switch ($schema['x-itemtype']) {
+            case 'User':
+                $schema['properties']['vip_groups'] = [
+                    'type' => \Glpi\Api\HL\Doc\Schema::TYPE_ARRAY,
+                    'items' => [
+                        'type' => \Glpi\Api\HL\Doc\Schema::TYPE_OBJECT,
+                        'x-join' => [
+                            // This is the join with the desired data
+                            'table' => 'glpi_plugin_vip_groups',
+                            'fkey' => 'groups_id',
+                            'field' => 'id', // This table uses the group ID as the primary key "id"
+                            'ref_join' => [
+                                // This is the linking join between the main item and the data needed
+                                'table' => 'glpi_groups_users',
+                                'fkey' => 'id',
+                                'field' => 'users_id',
+                            ]
+                        ],
+                        'properties' => [
+                            'id' => [
+                                'type' => \Glpi\Api\HL\Doc\Schema::TYPE_INTEGER,
+                                'x-readonly' => true,
+                            ],
+                            'name' => [
+                                'type' => \Glpi\Api\HL\Doc\Schema::TYPE_STRING,
+                                'x-readonly' => true,
+                            ],
+                            'color' => [
+                                'type' => \Glpi\Api\HL\Doc\Schema::TYPE_STRING,
+                                'x-readonly' => true,
+                                'x-field' => 'vip_color'
+                            ],
+                            'icon' => [
+                                'type' => \Glpi\Api\HL\Doc\Schema::TYPE_STRING,
+                                'x-readonly' => true,
+                                'x-field' => 'vip_icon'
+                            ],
+                        ]
+                    ]
+                ];
+                break;
+        }
+    }
+    return $data;
+}

--- a/setup.php
+++ b/setup.php
@@ -27,6 +27,8 @@
  --------------------------------------------------------------------------
  */
 
+use Glpi\Plugin\Hooks;
+
 define('PLUGIN_VIP_VERSION', '1.8.2');
 
 if (!defined("PLUGIN_VIP_DIR")) {
@@ -83,6 +85,8 @@ function plugin_init_vip() {
    Plugin::registerClass('PluginVipRuleVipCollection', [
        'rulecollections_types' => true
    ]);
+   // Cannot be placed inside any permission check as the plugin is initialized before the API router authenticates the user
+   $PLUGIN_HOOKS[Hooks::REDEFINE_API_SCHEMAS]['vip'] = 'plugin_vip_redefine_api_schemas';
 }
 
 function plugin_version_vip() {


### PR DESCRIPTION
Add integration with the new API coming in GLPI 10.1.

This integration adds a `vip_groups` array on the schema for `Users` where each item is read-only and has properties for the `id`, `name`, `color, and `icon`. The color and icon properties have been renamed from the column name by using the desired property name as the key and specifying the column name in the `x-field` property. For the other fields, the column is assumed to match the property name.

The new API is still a work in progress and this integration relies on a currently pending PR in the core to fix the handling of the column name overrides within joins.