### PR TITLE
Fix(Search): prevent duplicate Ticket

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -122,6 +122,7 @@ function plugin_vip_getAddSearchOptions($itemtype) {
             $sopt[$rng1]['name']          = 'Vip';
             $sopt[$rng1]['datatype']      = 'bool';
             $sopt[$rng1]['massiveaction'] = false;
+            $sopt[$rng1]['forcegroupby'] = true;
             break;
          case 'Group':
             $rng1                         = 10150;


### PR DESCRIPTION
Prevent duplicate tickets from being displayed when the “VIP” column is added (and an actor is marked as VIP)

![image](https://github.com/user-attachments/assets/fc891c60-db3b-4f10-9b95-466410c5acbf)


